### PR TITLE
Implement syscalls

### DIFF
--- a/src/lib/kernel/list.c
+++ b/src/lib/kernel/list.c
@@ -227,6 +227,26 @@ struct list_elem* list_pop_front(struct list* list) {
   return front;
 }
 
+/* Wrapper around list_remove, list_pop_front, list_pop_back 
+  This function assumes that the element is within the list provided
+*/
+bool list_remove_elem(struct list_elem* ele, struct list* lst) {
+  bool res = false;
+  if (is_interior(ele)) {
+    list_remove(ele);
+    res = true;
+  }
+  else if (is_head(ele) && &lst->head == ele) {
+    list_pop_front(lst);
+    res = true;
+  }
+  else if (is_tail(ele) && &lst->tail == ele) {
+    list_pop_back(lst);
+    res = true;
+  }
+  return res;
+}
+
 /* Removes the back element from LIST and returns it.
    Undefined behavior if LIST is empty before removal. */
 struct list_elem* list_pop_back(struct list* list) {

--- a/src/lib/kernel/list.h
+++ b/src/lib/kernel/list.h
@@ -171,4 +171,6 @@ void list_unique(struct list*, struct list* duplicates, list_less_func*, void* a
 struct list_elem* list_max(struct list*, list_less_func*, void* aux);
 struct list_elem* list_min(struct list*, list_less_func*, void* aux);
 
+bool list_remove_elem(struct list_elem* ele, struct list* lst);
+
 #endif /* lib/kernel/list.h */

--- a/src/lib/stdio.h
+++ b/src/lib/stdio.h
@@ -14,6 +14,7 @@
 /* Predefined file handles. */
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
+#define STDERR_FILENO 2
 
 /* Standard functions. */
 int printf(const char*, ...) PRINTF_FORMAT(1, 2);

--- a/src/lib/syscall-nr.h
+++ b/src/lib/syscall-nr.h
@@ -7,12 +7,13 @@ enum {
   SYS_HALT,         /* Halt the operating system. */
   SYS_EXIT,         /* Terminate this process. */
   SYS_EXEC,         /* Start another process. */
+  SYS_FORK,         /* Fork another child process */
   SYS_WAIT,         /* Wait for a child process to die. */
   SYS_CREATE,       /* Create a file. */
   SYS_REMOVE,       /* Delete a file. */
   SYS_OPEN,         /* Open a file. */
   SYS_FILESIZE,     /* Obtain a file's size. */
-  SYS_READ,         /* Read from a file. */
+  SYS_READ,         /* Rea[d from a file. */
   SYS_WRITE,        /* Write to a file. */
   SYS_SEEK,         /* Change position in a file. */
   SYS_TELL,         /* Report current position in a file. */

--- a/src/tests/userprog/Make.tests
+++ b/src/tests/userprog/Make.tests
@@ -19,7 +19,7 @@ wait-simple wait-twice wait-killed wait-bad-pid multi-recurse           \
 multi-child-fd rox-simple rox-child rox-multichild bad-read bad-write   \
 bad-read2 bad-write2 bad-jump bad-jump2 iloveos practice stack-align-1  \
 stack-align-2 stack-align-3 stack-align-4 floating-point fp-simul       \
-fp-asm fp-syscall fp-kernel-e fp-init)
+fp-asm fp-syscall fp-kernel-e fp-init stack-align-v)
 
 tests/userprog_PROGS = $(tests/userprog_TESTS) $(addprefix \
 tests/userprog/,child-simple child-args child-bad child-close \
@@ -33,6 +33,7 @@ tests/userprog/stack-align-1_SRC = tests/userprog/stack-align.c
 tests/userprog/stack-align-2_SRC = tests/userprog/stack-align.c
 tests/userprog/stack-align-3_SRC = tests/userprog/stack-align.c
 tests/userprog/stack-align-4_SRC = tests/userprog/stack-align.c
+tests/userprog/stack-align-v_SRC = tests/userprog/stack-align-v.c
 tests/userprog/args-none_SRC = tests/userprog/args.c
 tests/userprog/args-single_SRC = tests/userprog/args.c
 tests/userprog/args-multiple_SRC = tests/userprog/args.c

--- a/src/tests/userprog/stack-align-v.c
+++ b/src/tests/userprog/stack-align-v.c
@@ -1,0 +1,11 @@
+/* Does absolutely nothing. */
+
+#include "tests/lib.h"
+
+int main(int argc, char* argv[] UNUSED) {
+  register unsigned int esp asm("esp");
+  if (argc != 1)  // argc must be 1.
+    return -1;
+  else
+    return esp % 16;
+}

--- a/src/tests/userprog/stack-align-v.ck
+++ b/src/tests/userprog/stack-align-v.ck
@@ -1,0 +1,8 @@
+# -*- perl -*-
+use strict;
+use warnings;
+use tests::tests;
+check_expected ([<<'EOF']);
+stack-align-v: exit(8)
+EOF
+pass;

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -12,7 +12,7 @@ enum thread_status {
   THREAD_RUNNING, /* Running thread. */
   THREAD_READY,   /* Not running but ready to run. */
   THREAD_BLOCKED, /* Waiting for an event to trigger. */
-  THREAD_DYING    /* About to be destroyed. */
+  THREAD_DYING,   /* About to be destroyed. */
 };
 
 /* Thread identifier type.
@@ -89,6 +89,7 @@ struct thread {
   uint8_t* stack;            /* Saved stack pointer. */
   int priority;              /* Priority. */
   struct list_elem allelem;  /* List element for all threads list. */
+  struct list children;      /* Children of threads */
 
   /* Shared between thread.c and synch.c. */
   struct list_elem elem; /* List element. */
@@ -148,5 +149,7 @@ int thread_get_nice(void);
 void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
+
+struct thread* thread_find_child(struct thread* parent, tid_t tid);
 
 #endif /* threads/thread.h */

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -90,6 +90,8 @@ struct thread {
   int priority;              /* Priority. */
   struct list_elem allelem;  /* List element for all threads list. */
   struct list children;      /* Children of threads */
+  struct list_elem c_elem;  /* List element for children list */
+  struct thread* parent;      /* Parent of thread */
 
   /* Shared between thread.c and synch.c. */
   struct list_elem elem; /* List element. */

--- a/src/userprog/exception.c
+++ b/src/userprog/exception.c
@@ -1,8 +1,9 @@
-#include "userprog/exception.h"
 #include <inttypes.h>
 #include <stdio.h>
 #include "userprog/gdt.h"
 #include "userprog/process.h"
+#include "userprog/exception.h"
+#include "userprog/syscall.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
@@ -75,10 +76,11 @@ static void kill(struct intr_frame* f) {
     case SEL_UCSEG:
       /* User's code segment, so it's a user exception, as we
          expected.  Kill the user process.  */
+      struct thread *cur = thread_current();
       printf("%s: dying due to interrupt %#04x (%s).\n", thread_name(), f->vec_no,
              intr_name(f->vec_no));
       intr_dump_frame(f);
-      process_exit();
+      exit(TID_ERROR);
       NOT_REACHED();
 
     case SEL_KCSEG:

--- a/src/userprog/pagedir.c
+++ b/src/userprog/pagedir.c
@@ -6,6 +6,9 @@
 #include "threads/pte.h"
 #include "threads/palloc.h"
 
+#define PD_SIZE 1024  // Number of entries in the page directory
+#define PT_SIZE 1024  // Number of entries in the page table
+
 static void invalidate_pagedir(uint32_t*);
 
 /* Creates a new page directory that has mappings for kernel
@@ -15,7 +18,8 @@ static void invalidate_pagedir(uint32_t*);
 uint32_t* pagedir_create(void) {
   uint32_t* pd = palloc_get_page(0);
   if (pd != NULL)
-    memcpy(pd, init_page_dir, PGSIZE);
+    // Copy over kernel mappings from init_page_dir
+    memcpy(pd, init_page_dir, PGSIZE); // PGSIZE because pd is 32 bits
   return pd;
 }
 
@@ -205,6 +209,53 @@ uint32_t* active_pd(void) {
   uintptr_t pd;
   asm volatile("movl %%cr3, %0" : "=r"(pd));
   return ptov(pd);
+}
+
+/* Given a page directory, create a copy of it */
+uint32_t* pagedir_copy(uint32_t* pd) {
+  /* Create a new page directory */
+  uint32_t* new_pd = pagedir_create();
+  if (new_pd == NULL) return NULL;
+  
+  // Page dir layer
+  for (int i=0; i<PD_SIZE; i++) {
+    uint32_t pde = pd[i];
+    // If the pde is present and is a user page then copy it
+    if ((pde & PTE_P) && (pde & PTE_U)) {
+      // Get the old page table from the page directory entry
+      uint32_t* pt = pde_get_pt(pde);
+      // Allocate an empty page filled with zeros for the new page table from the kernel pool
+      // Since page tables are kernel structures
+      uint32_t* new_pt = palloc_get_page(PAL_ZERO);
+      if (new_pt == NULL) {
+        pagedir_destroy(new_pd);
+        return NULL;
+      }
+      // Page table layer
+      for (int j=0; j<PT_SIZE; j++) {
+        uint32_t pte = pt[j];
+        // If pte is present copy it
+        if (pte & PTE_P) {
+          // Get the old page
+          void* page = pte_get_page(pte);
+          // Allocate a new page from the user pool since these are user space data
+          void* new_page = palloc_get_page(PAL_USER);
+          if (new_page == NULL) {
+            pagedir_destroy(new_pd);
+            return NULL;
+          }
+          // Copy the contents of old page to new page
+          memcpy(new_page, page, PGSIZE);
+
+          new_pt[j] = pte_create_user(new_page, (pte & PTE_W) != 0);
+        }
+      }
+
+      new_pd[i] = pde_create(new_pt);
+    }
+  }
+
+  return new_pd;
 }
 
 /* Seom page table changes can cause the CPU's translation

--- a/src/userprog/pagedir.h
+++ b/src/userprog/pagedir.h
@@ -14,6 +14,7 @@ void pagedir_set_dirty(uint32_t* pd, const void* upage, bool dirty);
 bool pagedir_is_accessed(uint32_t* pd, const void* upage);
 void pagedir_set_accessed(uint32_t* pd, const void* upage, bool accessed);
 void pagedir_activate(uint32_t* pd);
+uint32_t* pagedir_copy(uint32_t* pd);
 uint32_t* active_pd(void);
 
 #endif /* userprog/pagedir.h */

--- a/src/userprog/process.c
+++ b/src/userprog/process.c
@@ -32,7 +32,18 @@ struct start_process_args {
   bool success;
 };
 
+struct fork_process_args {
+  struct process* parent;
+  struct intr_frame parent_if;
+  
+  /* Semaphore to track the success of the process */
+  struct semaphore fork_mutex;
+  bool success;
+};
+
 static thread_func start_process NO_RETURN;
+static void function_call_setup(struct function_signature *fs, void **esp);
+static thread_func start_fork NO_RETURN;
 static thread_func start_pthread NO_RETURN;
 static bool load(const char* file_name, void (**eip)(void), void** esp);
 bool setup_thread(void (**eip)(void), void** esp);
@@ -65,17 +76,21 @@ void userprog_init(void) {
    before process_execute() returns.  Returns the new process's
    process id, or TID_ERROR if the thread cannot be created. */
 pid_t process_execute(const char* file_name) {
+  // if (!is_user_vaddr(file_name) || pagedir_get_page(thread_current()->pcb->pagedir, file_name) ==  NULL) return -1;
   char* fn_copy;
   pid_t pid;
   /* Make a copy of FILE_NAME.
      Otherwise there's a race between the caller and load(). */
-  fn_copy = palloc_get_page(0);
+  fn_copy = malloc (sizeof (char) * (strlen (file_name) + 1));
   if (fn_copy == NULL)
-    return TID_ERROR;
+    return TID_ERROR; 
   strlcpy(fn_copy, file_name, PGSIZE);
 
   /* Init start_process args. Set the success value to false first and init the monitor construct */
   struct start_process_args* args = malloc(sizeof(struct start_process_args));
+  if (args == NULL) 
+    return -1;
+  
   sema_init(&args->init_mutex, 0);
   args->fn_signature = fn_copy;
   args->parent = thread_current()->pcb;
@@ -84,7 +99,7 @@ pid_t process_execute(const char* file_name) {
   /* Create a new thread to execute FILE_NAME. */
   pid = thread_create(file_name, PRI_DEFAULT, start_process, args);
   if (pid == TID_ERROR)
-    palloc_free_page(fn_copy);
+    free(fn_copy);
 
   /* Since the start_process function loads the pcb in a different kernel thread
     we need to block until we are done loading the process.
@@ -92,6 +107,38 @@ pid_t process_execute(const char* file_name) {
   sema_down(&args->init_mutex);
   bool success = args->success;
   /* Clean up the dynamic memory allocated by heap */
+  free(args);
+  return success ? pid: TID_ERROR;
+}
+
+/* Fork a child process 
+  To fork a child process we need to do the following:
+  1. Copy the virtual address
+*/
+pid_t process_fork(const char* file_name, struct intr_frame* parent_if) {
+  /* Set the current thread as the parent thread */
+  struct thread* parent = thread_current();
+
+  struct fork_process_args* args = malloc(sizeof(struct fork_process_args));
+  if (args == NULL)
+    return TID_ERROR;
+
+  sema_init(&args->fork_mutex, 0);
+  args->parent = thread_current()->pcb;
+  // Copy of parent interrupt frame so that child can continue from the exact same point as the parent
+  // but have its own independent interrupt frame
+  args->parent_if = *parent_if; 
+  args->success = false;
+
+  pid_t pid = thread_create(file_name, PRI_DEFAULT, start_fork, args);
+  if (pid == TID_ERROR) {
+    free(args);
+    return TID_ERROR;
+  }
+
+  /* Wait for child to finish initializing */
+  sema_down(&args->fork_mutex);
+  bool success = args->success;
   free(args);
   return success ? pid: TID_ERROR;
 }
@@ -107,17 +154,20 @@ static void start_process(void* args_) {
 
   // Tokenize the args
   char* argv[ARG_SIZE];
-  char* saveptr = argv;
+  char* saveptr;
   const char* delim = " ";
   char* token = strtok_r(file_name, delim, &saveptr);
   int argc = 0;
   struct function_signature* fs = malloc(sizeof(struct function_signature));
 
-  while (token != NULL) {
+  char* exec_name = malloc(strlen(token) + 1);
+  strlcpy(exec_name, token, strlen(token) + 1); // Safe copy
+
+  argv[argc++] = token;
+  while ((token = strtok_r(NULL, " ", &saveptr)) != NULL)
     argv[argc++] = token;
-    token = strtok_r(NULL, delim, &saveptr);
-  }
-  fs->file_name = file_name;
+  
+  fs->file_name = exec_name;
   fs->argv = argv;
   fs->argc = argc;
 
@@ -134,10 +184,15 @@ static void start_process(void* args_) {
 
     // Continue initializing the PCB as normal
     t->pcb->main_thread = t;
-    strlcpy(t->pcb->process_name, t->name, sizeof t->name);
+    strlcpy(t->pcb->process_name, argv[0], sizeof t->name);
     t->pcb->pid = t->tid; // Set the pid of the process
     sema_init(&t->pcb->wait_sem, 0);
     list_init(&t->pcb->children);
+
+    // Initialize the file descriptor table
+    for (int i=0; i<FDT_SIZE; i++) {
+      new_pcb->fd_table[i] = NULL;
+    }
   }
 
   /* Initialize interrupt frame and load executable. */
@@ -147,7 +202,6 @@ static void start_process(void* args_) {
     if_.cs = SEL_UCSEG;
     if_.eflags = FLAG_IF | FLAG_MBS;
     success = load(fs->file_name, &if_.eip, &if_.esp);
-    if_.esp = if_.esp - 12;
   }
 
   /* Handle failure with succesful PCB malloc. Must free the PCB */
@@ -163,9 +217,9 @@ static void start_process(void* args_) {
   if (success) function_call_setup(fs, &if_.esp);
 
   /* Clean up. Exit on failure or jump to userspace */
-  palloc_free_page(fs->file_name);
+  free(fs->file_name);
+  free(file_name);
   if (!success) {
-    sema_up(&t->pcb->wait_sem);
     sema_up(&args->init_mutex);
     thread_exit();
   }
@@ -181,6 +235,52 @@ static void start_process(void* args_) {
      we just point the stack pointer (%esp) to our stack frame
      and jump to it. */
   asm volatile("movl %0, %%esp; jmp intr_exit" : : "g"(&if_) : "memory");
+  NOT_REACHED();
+}
+
+static void start_fork(void* args_) {
+  struct fork_process_args* args = (struct fork_process_args*) args_;
+  struct thread* t = thread_current();
+  struct process* parent = args->parent;
+
+  struct process* child = malloc(sizeof(struct process));
+  if (child == NULL) {
+    args->success = false;
+    sema_up(&args->fork_mutex);
+    thread_exit();
+  }
+
+  child->pid = t->tid;
+  strlcpy(child->process_name, parent->process_name, sizeof(parent->process_name));
+  child->main_thread = t;
+  child->parent_pid = parent->pid;
+  sema_init(&child->wait_sem, 0);
+  list_init(&child->children);
+  t->pcb = child;
+
+  child->pagedir = pagedir_copy(parent->pagedir);
+  if (child->pagedir == NULL) {
+    free(child);
+    args->success = false;
+    sema_up(&args->fork_mutex);
+    thread_exit();
+  }
+
+  for (int fd=0; fd<FDT_SIZE; fd++) {
+    if (parent->fd_table[fd] != NULL) {
+      child->fd_table[fd] = file_reopen(parent->fd_table[fd]);
+    } else {
+      child->fd_table[fd] = NULL;
+    }
+  }
+
+  struct intr_frame child_if = args->parent_if;
+  child_if.eax = 0;
+
+  args->success = true;
+  sema_up(&args->fork_mutex);
+
+  asm volatile("movl %0, %%esp; jmp intr_exit" : : "g"(&child_if) : "memory");
   NOT_REACHED();
 }
 
@@ -204,17 +304,22 @@ void function_call_setup(struct function_signature* fs, void** esp) {
     argv_addresses[i] = (char *) *esp;
   }
 
-  // Align stack pointer for 32-bit address alignment (4 bytes)
-  size_t alignment = ((size_t)*esp % 4);
-  if (alignment != 0) {
-    *esp -= alignment;
-    memset(*esp, 0, alignment); // Optionally clear the added space
-  }
+  // Align stack
+  // Simulate how much alignment we need to remove so that 
+  // when we push the fake return address, the alignment is right
+  int diff = sizeof(char *) + sizeof(char *) * fs->argc + sizeof(char **) + sizeof(int *) + sizeof(void *);
+  int alignment = ((int) *esp - diff + sizeof(void *)) % 16;
+  *esp -= alignment < 0 ? alignment + 16 : alignment;
+
+  // Push null sentinel
+  *esp -= sizeof(char *);
+  *((char **) *esp) = NULL;
 
   // Push addresses of arguments (argv[])
-  size_t argv_addresses_size = (fs->argc + 1) * sizeof(char*);
-  *esp -= argv_addresses_size;
-  memcpy(*esp, argv_addresses, argv_addresses_size);
+  for (int i = fs->argc - 1; i >= 0; i--) {
+    *esp -= sizeof(char *);
+    memcpy(*esp, &argv_addresses[i], sizeof(char *));
+  }
 
   // Push argv address
   // 0xbfffffe1
@@ -226,9 +331,8 @@ void function_call_setup(struct function_signature* fs, void** esp) {
   *((int *) *esp) = fs->argc;
 
   // Push return address
-  size_t fake_ra = 0;
-  *esp -= 4;
-  memcpy(*esp, &fake_ra, 4);
+  *esp -= sizeof(void *);
+  *((void **) *esp) = 0;
 }
 
 /* Waits for process with PID child_pid to die and returns its exit status.
@@ -243,9 +347,9 @@ void function_call_setup(struct function_signature* fs, void** esp) {
 int process_wait(pid_t child_pid) {
   struct thread* parent = thread_current();
   struct process* child_pcb = process_find_child(parent->pcb, child_pid);
-  if (!child_pcb) return EXIT_PROCESS_NOT_FOUND;
-  if (!process_is_child(child_pcb, parent->pcb)) return EXIT_PROCESS_NOT_FOUND;
-  if (!child_pcb) return EXIT_PROCESS_NOT_FOUND;
+  if (!child_pcb) return EXIT_PROCESS_FAILURE;
+  if (!process_is_child(child_pcb, parent->pcb)) return EXIT_PROCESS_FAILURE;
+  if (!child_pcb) return EXIT_PROCESS_FAILURE;
 
   int status = EXIT_PROCESS_FAILURE;
   
@@ -258,7 +362,7 @@ int process_wait(pid_t child_pid) {
   status = child_pcb->exit_status;
 
   /* Free the PCB of this process */
-  list_remove_elem(child_pcb, &parent->pcb->children);
+  list_remove_elem(&child_pcb->elem, &parent->pcb->children);
   struct process* pcb_to_free = child_pcb;
   free(pcb_to_free);
 
@@ -274,6 +378,13 @@ void process_exit(void) {
   if (cur->pcb == NULL) {
     thread_exit();
     NOT_REACHED();
+  }
+
+  // Release the executable file
+  if (cur->pcb->executable != NULL) {
+    file_allow_write(cur->pcb->executable);
+    file_close(cur->pcb->executable);
+    cur->pcb->executable = NULL;
   }
 
   /* Destroy the current process's page directory and switch back
@@ -292,8 +403,19 @@ void process_exit(void) {
     pagedir_destroy(pd);
   }
 
+  /* Cleanup fd_table */
+  for (int i=0; i<FDT_SIZE; i++) {
+    if (cur->pcb->fd_table[i] != NULL) {
+      file_close(cur->pcb->fd_table[i]);
+      cur->pcb->fd_table[i] = NULL;
+    }
+  }
+
   /* Increment semaphore to signal that the process is done */
   sema_up(&cur->pcb->wait_sem);
+
+  thread_exit();
+  NOT_REACHED();
 }
 
 /* Sets up the CPU for running user code in the current
@@ -403,6 +525,10 @@ bool load(const char* file_name, void (**eip)(void), void** esp) {
     goto done;
   }
 
+  // Deny writes to the executable when running
+  file_deny_write(file);
+  t->pcb->executable = file;
+
   /* Read and verify executable header. */
   if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr ||
       memcmp(ehdr.e_ident, "\177ELF\1\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 3 ||
@@ -472,7 +598,6 @@ bool load(const char* file_name, void (**eip)(void), void** esp) {
 
 done:
   /* We arrive here whether the load is successful or not. */
-  file_close(file);
   return success;
 }
 

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -39,6 +39,8 @@ struct process {
 	pid_t parent_pid;															/* Parent pid of the process */
 	enum process_exit_status exit_status;        	/* Exit status of a process */
   struct semaphore wait_sem;                 		/* Semaphore. Blocks until all child threads exits */
+	struct list children;													/* Children processes. Different from children threads */
+	struct list_elem elem;												/* List elem */
 };
 
 struct function_signature {
@@ -55,6 +57,7 @@ void process_exit(void);
 void process_activate(void);
 void process_set_child(struct process* parent, struct process* child);
 bool process_is_child(struct process* child, struct process* parent);
+struct process* process_find_child(struct process* parent, pid_t child_pid);
 
 bool is_main_thread(struct thread*, struct process*);
 pid_t get_pid(struct process*);

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -2,6 +2,8 @@
 #define USERPROG_PROCESS_H
 
 #include "threads/thread.h"
+#include "threads/synch.h"
+#include <list.h>
 #include <stdint.h>
 
 // At most 8MB can be allocated to the stack
@@ -17,6 +19,12 @@ typedef tid_t pid_t;
 typedef void (*pthread_fun)(void*);
 typedef void (*stub_fun)(pthread_fun, void*);
 
+enum process_exit_status {
+  EXIT_PROCESS_SUCCESS = 0,       // PROCESS completed successfully
+  EXIT_PROCESS_FAILURE = -1,      // General failure
+  EXIT_PROCESS_NOT_FOUND = -2,		// Invalid pid or pid not child of parent process (process calling wait syscall)
+};
+
 /* The process control block for a given process. Since
    there can be multiple threads per process, we need a separate
    PCB from the TCB. All TCBs in a process will have a pointer
@@ -24,9 +32,19 @@ typedef void (*stub_fun)(pthread_fun, void*);
    of the process, which is `special`. */
 struct process {
   /* Owned by process.c. */
-  uint32_t* pagedir;          /* Page directory. */
-  char process_name[16];      /* Name of the main thread */
-  struct thread* main_thread; /* Pointer to main thread */
+	pid_t pid;																		/* pid of the process. pid = tid of the process kernel thread*/
+  uint32_t* pagedir;          									/* Page directory. */
+  char process_name[16];      									/* Name of the main thread */
+  struct thread* main_thread; 									/* Pointer to main thread */
+	pid_t parent_pid;															/* Parent pid of the process */
+	enum process_exit_status exit_status;        	/* Exit status of a process */
+  struct semaphore wait_sem;                 		/* Semaphore. Blocks until all child threads exits */
+};
+
+struct function_signature {
+  char* file_name;
+  char** argv;
+  int argc;
 };
 
 void userprog_init(void);
@@ -35,6 +53,8 @@ pid_t process_execute(const char* file_name);
 int process_wait(pid_t);
 void process_exit(void);
 void process_activate(void);
+void process_set_child(struct process* parent, struct process* child);
+bool process_is_child(struct process* child, struct process* parent);
 
 bool is_main_thread(struct thread*, struct process*);
 pid_t get_pid(struct process*);

--- a/src/userprog/process.h
+++ b/src/userprog/process.h
@@ -3,6 +3,7 @@
 
 #include "threads/thread.h"
 #include "threads/synch.h"
+#include "threads/interrupt.h"
 #include <list.h>
 #include <stdint.h>
 
@@ -10,6 +11,8 @@
 // These defines will be used in Project 2: Multithreading
 #define MAX_STACK_PAGES (1 << 11)
 #define MAX_THREADS 127
+
+#define FDT_SIZE 128
 
 /* PIDs and TIDs are the same type. PID should be
    the TID of the main thread of the process */
@@ -33,7 +36,9 @@ enum process_exit_status {
 struct process {
   /* Owned by process.c. */
 	pid_t pid;																		/* pid of the process. pid = tid of the process kernel thread*/
+  struct file* executable;                      /* File executable */
   uint32_t* pagedir;          									/* Page directory. */
+  struct file* fd_table[FDT_SIZE];              /* File descriptor table */
   char process_name[16];      									/* Name of the main thread */
   struct thread* main_thread; 									/* Pointer to main thread */
 	pid_t parent_pid;															/* Parent pid of the process */
@@ -52,6 +57,7 @@ struct function_signature {
 void userprog_init(void);
 
 pid_t process_execute(const char* file_name);
+pid_t process_fork(const char* file_name, struct intr_frame* parent_if);
 int process_wait(pid_t);
 void process_exit(void);
 void process_activate(void);

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -23,15 +23,16 @@ static void syscall_handler(struct intr_frame* f UNUSED) {
   /* printf("System call number: %d\n", args[0]); */
 
   if (args[0] == SYS_EXIT) {
-    f->eax = args[1];
+    thread_current()->pcb->exit_status = args[1];
     printf("%s: exit(%d)\n", thread_current()->pcb->process_name, args[1]);
     process_exit();
+    thread_exit();
   } else if (args[0] == SYS_PRACTICE) {
     f->eax = args[1] + 1;
   } else if (args[0] == SYS_HALT) {
     shutdown_power_off();
   } else if (args[0] == SYS_EXEC) {
-    process_execute((char*) args[1]);
+    f->eax = process_execute((char*) args[1]);
   } else if (args[0] == SYS_WAIT) {
     f->eax = process_wait(args[1]);
   }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -4,6 +4,7 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "userprog/process.h"
+#include "devices/shutdown.h"
 
 static void syscall_handler(struct intr_frame*);
 
@@ -25,5 +26,13 @@ static void syscall_handler(struct intr_frame* f UNUSED) {
     f->eax = args[1];
     printf("%s: exit(%d)\n", thread_current()->pcb->process_name, args[1]);
     process_exit();
+  } else if (args[0] == SYS_PRACTICE) {
+    f->eax = args[1] + 1;
+  } else if (args[0] == SYS_HALT) {
+    shutdown_power_off();
+  } else if (args[0] == SYS_EXEC) {
+    process_execute((char*) args[1]);
+  } else if (args[0] == SYS_WAIT) {
+    f->eax = process_wait(args[1]);
   }
 }

--- a/src/userprog/syscall.c
+++ b/src/userprog/syscall.c
@@ -3,15 +3,30 @@
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
+#include "threads/vaddr.h"
 #include "userprog/process.h"
+#include "userprog/pagedir.h"
 #include "devices/shutdown.h"
+#include "devices/input.h"
+#include "filesys/filesys.h"
+#include "filesys/file.h"
 
 static void syscall_handler(struct intr_frame*);
 
+static bool validate_user_ptr(const void *);
+
+static bool validate_range(const void *start, size_t size);
+
+static bool validate_string(const char *str);
+
 void syscall_init(void) { intr_register_int(0x30, 3, INTR_ON, syscall_handler, "syscall"); }
 
-static void syscall_handler(struct intr_frame* f UNUSED) {
+static void syscall_handler(struct intr_frame* f) {
   uint32_t* args = ((uint32_t*)f->esp);
+  if (!validate_range(f->esp, 4)) {
+    exit(-1);
+    NOT_REACHED();
+  }
 
   /*
    * The following print statement, if uncommented, will print out the syscall
@@ -23,17 +38,268 @@ static void syscall_handler(struct intr_frame* f UNUSED) {
   /* printf("System call number: %d\n", args[0]); */
 
   if (args[0] == SYS_EXIT) {
-    thread_current()->pcb->exit_status = args[1];
-    printf("%s: exit(%d)\n", thread_current()->pcb->process_name, args[1]);
-    process_exit();
-    thread_exit();
+    if (!validate_range(f->esp + 4, 4)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    exit(args[1]);
+    NOT_REACHED();
   } else if (args[0] == SYS_PRACTICE) {
-    f->eax = args[1] + 1;
+    f->eax = practice(args[1]);
   } else if (args[0] == SYS_HALT) {
-    shutdown_power_off();
+    halt();
+    NOT_REACHED();
   } else if (args[0] == SYS_EXEC) {
-    f->eax = process_execute((char*) args[1]);
+    if (!validate_range(f->esp + 4, 4)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = exec((char*) args[1]);
   } else if (args[0] == SYS_WAIT) {
-    f->eax = process_wait(args[1]);
+    f->eax = wait(args[1]);
+  } else if (args[0] == SYS_FORK) {
+    f->eax = process_fork((char*) args[1], f);
+  } else if (args[0] == SYS_CREATE) {
+    if (!validate_range(f->esp + 4, 8) || !validate_string((char*) args[1])) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = create((char*) args[1], args[2]);
+  } else if (args[0] == SYS_REMOVE) {
+    if (!validate_range(f->esp + 4, 4) || !validate_string((char*) args[1])) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = remove((char*) args[1]);
+  } else if (args[0] == SYS_OPEN) {
+    if (!validate_range(f->esp + 4, 4) || !validate_string((char*) args[1])) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = open((char*) args[1]);
+  } else if (args[0] == SYS_FILESIZE) {
+    if (!validate_range(f->esp + 4, 4)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = filesize(args[1]);
+  } else if (args[0] == SYS_READ) {
+    if (!validate_range(f->esp + 4, 12)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    int fd = (int) args[1];
+    void* buffer = (void *) args[2];
+    unsigned size = (unsigned) args[3];
+
+    if (!validate_range(buffer, size)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = read(fd, buffer, size);
+  } else if (args[0] == SYS_WRITE) {
+    if (!validate_range(f->esp + 4, 12)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    int fd = (int) args[1];
+    void* buffer = (void *) args[2];
+    unsigned size = (unsigned) args[3];
+
+    if (!validate_range(buffer, size)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = write(fd, buffer, size);
+  } else if (args[0] == SYS_SEEK) {
+    if (!validate_range(f->esp + 4, 8)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    seek(args[1], args[2]);
+  } else if (args[0] == SYS_TELL) {
+    if (!validate_range(f->esp + 4, 4)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    f->eax = tell(args[1]);
+  } else if (args[0] == SYS_CLOSE) {
+    if (!validate_range(f->esp + 4, 4)) {
+      exit(-1);
+      NOT_REACHED();
+    }
+    close(args[1]);
+  } else {
+    exit(-1);
+    NOT_REACHED();
   }
+}
+
+/* Syscall wrappers that includes validating user pointers */
+
+int exit(int status) {
+  struct thread *cur = thread_current();
+  cur->pcb->exit_status = status;  // Set status from syscall
+  printf("%s: exit(%d)\n", cur->pcb->process_name, status);
+  process_exit();  // process_exit() calls thread_exit() internally
+  NOT_REACHED();   // Prevent compiler warnings
+}
+
+int practice(int num) {
+  return num + 1;
+}
+
+void halt() {
+  shutdown_power_off();
+}
+
+int exec(const char* file) {
+  if (!validate_string(file)) {
+    exit(-1);
+    NOT_REACHED();
+  }
+  return process_execute(file);
+}
+
+int wait(int pid) {
+  return process_wait(pid);
+}
+
+// int fork(const char* file, const struct intr_frame* f) {
+//   return 0;
+// }
+
+bool create(const char* file, unsigned initial_size) {
+  return filesys_create(file, initial_size);
+}
+
+bool remove(const char* file) {
+  return filesys_remove(file);
+}
+
+int open(const char* file) {
+  struct file* f = filesys_open(file);
+  if (f == NULL) return -1; // Failed to open
+
+  struct process* cur_process = thread_current()->pcb;
+  int fd = STDERR_FILENO + 1;
+  while (fd < FDT_SIZE && cur_process->fd_table[fd] != NULL) ++fd;
+  if (fd >= FDT_SIZE) {
+    file_close(f);
+    return -1;
+  }
+  cur_process->fd_table[fd] = f;
+  return fd;
+}
+
+int filesize(int fd) {
+  if (fd >= FDT_SIZE || fd < 0) return -1;
+  struct file *f = thread_current()->pcb->fd_table[fd];
+  return f != NULL ? file_length(f) : -1;
+}
+
+int read(int fd, void* buffer, unsigned size) {
+  if (fd >= FDT_SIZE || fd < 0) return -1;
+  if (fd == STDIN_FILENO) {
+    uint8_t* buf = buffer;
+    for (size_t i=0; i<size; i++) {
+      buf[i] = input_getc();
+    }
+    return size;
+  }
+    
+  struct file* file = thread_current()->pcb->fd_table[fd];
+  if (file == NULL) {
+    return -1;
+  }
+  if (size > filesize(fd)) return -1;
+  return file_read(file, buffer, size);
+}
+
+int write(int fd, const void* buffer, unsigned size) {
+  if (fd >= FDT_SIZE || fd < 0) return -1;
+  if (fd == STDOUT_FILENO) {
+    putbuf(buffer, size);
+    return size;
+  }
+
+  struct file* file = thread_current()->pcb->fd_table[fd];
+  if (file == NULL) {
+    return -1;
+  }
+  
+  return file_write(file, buffer, size);
+}
+
+int tell(int fd) {
+  if (fd < 0 || fd >= FDT_SIZE) return -1;
+  struct file* f = thread_current()->pcb->fd_table[fd];
+  if (f == NULL) return -1;
+  return file_tell(f);
+}
+
+void seek(int fd, unsigned position) {
+  if (fd < 0 || fd >= FDT_SIZE) return;
+  struct file* f = thread_current()->pcb->fd_table[fd];
+  if (f == NULL) return;
+  file_seek(f, position);
+}
+
+void close(int fd) {
+  if (fd < 0 || fd >= FDT_SIZE) return;
+  struct process* pcb = thread_current()->pcb;
+  struct file* f = pcb->fd_table[fd];
+  if (f != NULL) {
+    file_close(f);
+    pcb->fd_table[fd] = NULL;
+  }
+}
+
+/* Helper functions for validating user given pointers */
+
+static bool validate_user_ptr(const void *usr_ptr) {
+  // If its not null or an address in user space
+  if (usr_ptr == NULL || !is_user_vaddr(usr_ptr)) 
+    return false;
+
+  struct thread *cur = thread_current();
+  void* page_base = pg_round_down(usr_ptr);
+
+  // If ptr to page is NULL, means it does not reside in memory
+  // Currently no demand paging implemented.
+  // TODO implement demand paging
+  if (pagedir_get_page(cur->pcb->pagedir, page_base) != NULL)
+        return true;
+  
+  return false;
+}
+
+static bool validate_range(const void *start, size_t size) {
+  const uint8_t *ptr = start;
+  const uint8_t *end = ptr + size;
+
+  while (ptr < end) {
+      // Check if the current page is valid
+      if (!validate_user_ptr(ptr)) {
+          return false;
+      }
+      // Move to the next page
+      ptr = pg_round_down(ptr) + PGSIZE;
+  }
+  return true;
+}
+
+static bool validate_string(const char *str) {
+  if (str == NULL) {
+      return false;
+  }
+  for (size_t i = 0; i < 4096; i++) {
+      if (!validate_user_ptr(str + i)) {
+          return false;
+      }
+      if (str[i] == '\0') {
+          return true;
+      }
+  }
+  return false; // Exceeds max length or no null terminator
 }

--- a/src/userprog/syscall.h
+++ b/src/userprog/syscall.h
@@ -1,6 +1,24 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
+#include <stdbool.h>
+
 void syscall_init(void);
+
+int exit(int status);
+int practice(int num);
+void halt();
+int exec(const char* file);
+int wait(int pid);
+// int fork(const char* file, const struct intr_frame* f);
+bool create(const char *file, unsigned initial_size);
+bool remove(const char *file);
+int open(const char* file);
+int filesize(int fd);
+int read(int fd, void* buffer, unsigned size);
+int write(int fd, const void* buffer, unsigned size);
+void close(int fd);
+// void seek(int fd, unsigned position);
+// unsigned tell(int fd);
 
 #endif /* userprog/syscall.h */


### PR DESCRIPTION
# Context
In this MR, we seek to implement the process control syscalls and the file system syscalls.

# Design Decisions
## process_execute
process_execute spins up a kernel thread that runs start_process doing the following:
1. Tokenize the arguments
2. Allocate and initialize the pcb which includes setting up the page directory and the file descriptor table
3. Initialize the interrupt frame and load the ELF executable into the current thread
4. Push the arguments into the call stack as per the x86 call convention
5. note that we will also disallow write into the executable file.
Once that is done, the init_mutex will be released to the current thread and we return the pid or TID_ERROR.

## process_wait
1. Check if the child process is completed using the pcb wait_sem, otherwise block
2. The current child is a zombie, fetch the status of the child
3. Free the child pcb
4. return the status

## process_exit
1. Allow write to the executable file, and close the file
2. Destroy the process page directory
3. Clean up the file descriptor table
4. Increment the semaphore
5. Call thread_exit() which will reschedule the kernel thread

## process_fork
1. Allocate pcb and copy the page table
2. Copy the file descriptor and reopen the file